### PR TITLE
Switch patch

### DIFF
--- a/sources/event.hpp
+++ b/sources/event.hpp
@@ -295,7 +295,7 @@ struct EventFilter
 
 inline Event::State event_state(Uint32 type)
 {
-	return Event::State{ SDL_GetEventState(type) };
+	return static_cast<Event::State>(SDL_GetEventState(type));
 }
 
 inline void set_event_state(Uint32 type, Event::State state)

--- a/sources/exception.hpp
+++ b/sources/exception.hpp
@@ -1,13 +1,20 @@
 #pragma once
 
+
 #include <stdexcept>
 #include <string>
 #include <string_view>
 
 #include <SDL2/SDL_error.h>
 
+#ifdef CPP_SDL2_NOEXCEPTIONS
+#include <iostream> //Instead of throwing, we are going to dump the function and error into stderr via std::cerr
+#endif
+
 namespace sdl
 {
+
+#ifndef CPP_SDL2_NOEXCEPTIONS
 
 class Exception : public std::runtime_error
 {
@@ -33,5 +40,23 @@ private:
 	std::string function_;
 	std::string error_;
 };
+#else
+
+#define throw
+class Exception
+{
+public:
+	Exception(std::string const& function)
+	{
+		std::cerr << "Error in : " << function << "\n";
+		const auto error = SDL_GetError();
+		std::cerr << "Error : " << error << "\n";
+		abort();
+	}
+};
+
+
+#endif
 
 } // namespace sdl
+

--- a/sources/vec2.hpp
+++ b/sources/vec2.hpp
@@ -26,8 +26,8 @@ public:
 
 	constexpr Vec2(SDL_Point const& p) : Base{ p.x, p.y } {}
 
-	Vec2(Vec2 const&) noexcept = default;
-	Vec2(Vec2&&) noexcept = default;
+	constexpr Vec2(Vec2 const&) noexcept = default;
+	constexpr Vec2(Vec2&&) noexcept = default;
 
 	template <typename A>
 	static constexpr Vec2 from_polar(A alpha, T radius)
@@ -38,41 +38,41 @@ public:
 	Vec2& operator=(Vec2 const&) noexcept = default;
 	Vec2& operator=(Vec2&&) noexcept = default;
 	
-	Vec2 operator-() const { return Vec2{ -x, -y }; }
+	constexpr Vec2 operator-() const { return Vec2{ -Base::x, -Base::y }; }
 	
-	Vec2& operator+=(Vec2 const& other) { x += other.x; y += other.y; return *this; }
-	Vec2& operator-=(Vec2 const& other) { x -= other.x; y -= other.y; return *this; }
-	Vec2& operator*=(T value) { x *= value; y *= value; return *this; }
-	Vec2& operator/=(T value) { x /= value; y /= value; return *this; }
+	Vec2& operator+=(Vec2 const& other) { Base::x += other.x; Base::y += other.y; return *this; }
+	Vec2& operator-=(Vec2 const& other) { Base::x -= other.x; Base::y -= other.y; return *this; }
+	Vec2& operator*=(T value) { Base::x *= value; Base::y *= value; return *this; }
+	Vec2& operator/=(T value) { Base::x /= value; Base::y /= value; return *this; }
 
-	Vec2 operator+(Vec2 const& other) const { return Vec2{ x, y } += other; }
-	Vec2 operator-(Vec2 const& other) const { return Vec2{ x, y } -= other; }
-	Vec2 operator*(T value) const { return Vec2{ x, y } *= value; }
-	Vec2 operator/(T value) const { return Vec2{ x, y } /= value; }
+	constexpr Vec2 operator+(Vec2 const& other) const { return Vec2{ Base::x, Base::y } += other; }
+	constexpr Vec2 operator-(Vec2 const& other) const { return Vec2{ Base::x, Base::y } -= other; }
+	constexpr Vec2 operator*(T value) const { return Vec2{ Base::x, Base::y } *= value; }
+	constexpr Vec2 operator/(T value) const { return Vec2{ Base::x, Base::y } /= value; }
 
-	friend Vec2 operator*(T lhs, Vec2 const& rhs) { return rhs * lhs; }
+	friend constexpr Vec2 operator*(T lhs, Vec2 const& rhs) { return rhs * lhs; }
 
 	Vec2 clamped(SDL_Rect const& box) const
 	{
-		auto r = Vec2{ x, y };
+		auto r = Vec2{ Base::x, Base::y };
 		r.clamp(box);
 		return r;
 	}
 
 	void clamp(SDL_Rect const& box)
 	{
-		x = clamp(x, box.x, box.x + box.w);
-		y = clamp(y, box.y, box.y + box.h);
+		Base::x = clamp(Base::x, box.x, box.x + box.w);
+		Base::y = clamp(Base::y, box.y, box.y + box.h);
 	}
 
-	T length() const { return std::sqrt(x * x + y * y); }
-	T sqlength() const { return x * x + y * y; }
+	T length() const { return std::sqrt(Base::x * Base::x + Base::y * Base::y); }
+	T sqlength() const { return Base::x * Base::x + Base::y * Base::y; }
 
-	bool is_null() const { return x == T(0.0L) || y == T(0.0L); }
+	bool is_null() const { return Base::x == T(0.0L) || Base::y == T(0.0L); }
 
 	Vec2 normalized() const
 	{
-		auto r = Vec2{ x, y };
+		auto r = Vec2{ Base::x, Base::y };
 		r.normalize();
 		return r;
 	}
@@ -81,15 +81,15 @@ public:
 	{
 		if (is_null()) return;
 
-		auto l = length();
-		x /= l;
-		y /= l;
+		const auto l = length();
+		Base::x /= l;
+		Base::y /= l;
 	}
 
 	template <typename U>
 	explicit operator Vec2<U>() const
 	{
-		return Vec2<U>{ static_cast<U>(x), static_cast<U>(y) };
+		return Vec2<U>{ static_cast<U>(Base::x), static_cast<U>(Base::y) };
 	}
 
 	friend std::ostream& operator<<(std::ostream& stream, Vec2 const& v)
@@ -98,7 +98,7 @@ public:
 	}
 
 private:
-	T clamp(T x, T a, T b) { return std::min(std::max(x, a), b); }
+	T clamp(T x, T a, T b) { return std::min(std::max(Base::x, a), b); }
 };
 
 


### PR DESCRIPTION
Hi,

Here's some small changes that permit to use this library with the devkita64/libnx/SDL2 toolchain (currently based on GCC 8) to develop home brews on the Switch.

Basically, the code has to be buildable without RTTI and Exception support, and for some reason, the content of the parent class `Base` of Vec2 has to be explicitly named as `Base::x`

The changes made into Exception.hpp aren't pretty. This could probably done better, but hey, it works for all the occurrences of `throw Exception{"func"}` inside this codebase. 

