### PR TITLE
Fix LLVM build (IWYU: Add forgoten cmath header)

### DIFF
--- a/sources/vec2.hpp
+++ b/sources/vec2.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <ostream>
+#include <cmath>
 #include <SDL2/SDL_rect.h>
 
 namespace sdl::details


### PR DESCRIPTION
This permit to use cpp-sdl2 under emscripten (and web assembly)