### PR TITLE
Add Window.getWMInfo() interface

### DIFF
--- a/sources/window.hpp
+++ b/sources/window.hpp
@@ -118,7 +118,7 @@ public:
 	{
 		SDL_SysWMinfo info;
 		SDL_VERSION(&info.version);
-		if(SDL_GetWindowWMInfo(window_, &info) == SDL_FALSE)
+		if (SDL_GetWindowWMInfo(window_, &info) == SDL_FALSE)
 		{
 			throw Exception("SDL_GetWindowWMInfo");
 		}

--- a/sources/window.hpp
+++ b/sources/window.hpp
@@ -117,6 +117,7 @@ public:
 	SDL_SysWMinfo getWMInfo()
 	{
 		SDL_SysWMinfo info;
+		SDL_VERSION(&info.version);
 		if(SDL_GetWindowWMInfo(window_, &info) == SDL_FALSE)
 		{
 			throw Exception("SDL_GetWindowWMInfo");

--- a/sources/window.hpp
+++ b/sources/window.hpp
@@ -2,7 +2,7 @@
 
 #include <string>
 #include <SDL2/SDL.h>
-#include <SDL_syswm.h>
+#include <SDL2/SDL_syswm.h>
 
 #include "renderer.hpp"
 #include "vec2.hpp"

--- a/sources/window.hpp
+++ b/sources/window.hpp
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <SDL2/SDL.h>
+#include <SDL_syswm.h>
 
 #include "renderer.hpp"
 #include "vec2.hpp"
@@ -112,6 +113,16 @@ public:
 	}
 
 	Window& toogle_fullscreen() { return set_fullscreen(!fullscreen()); }
+
+	SDL_SysWMinfo getWMInfo()
+	{
+		SDL_SysWMinfo info;
+		if(SDL_GetWindowWMInfo(window_, &info) == SDL_FALSE)
+		{
+			throw Exception("SDL_GetWindowWMInfo");
+		}
+		return info;
+	}
 
 private:
 

--- a/sources/window.hpp
+++ b/sources/window.hpp
@@ -114,7 +114,7 @@ public:
 
 	Window& toogle_fullscreen() { return set_fullscreen(!fullscreen()); }
 
-	SDL_SysWMinfo getWMInfo()
+	SDL_SysWMinfo wm_info()
 	{
 		SDL_SysWMinfo info;
 		SDL_VERSION(&info.version);


### PR DESCRIPTION
This is useful to be able to hook the SDL with anything else that would be able to use it's window (like a Vulkan surface, or like letting an engine like Ogre draw inside the window by itself)