### PR TITLE
Make sdl image optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ By default, the code will throw exception in case of an SDL_Error. The Exception
 
 Exception support can be disabled by defining `CPP_SDL2_NOEXCEPTIONS` in the preprocessor. 
 
+To be able to easilly load images into surfaces, you can install SDL_Image 2, and define `CPP_SDL2_USE_SDL_IMAGE`
+
 ## Dependencies
 
 - SDL2
-- SDL_image 2
+- SDL_image 2 (optional)
 
 You will need a C++17 complient compiler
 

--- a/sources/surface.hpp
+++ b/sources/surface.hpp
@@ -87,7 +87,10 @@ public:
 	Surface(std::string const& filename)
 		: surface_{nullptr}
 	{
-		if (!surface_) throw Exception{ "ctor using IMG_Load has been stubbed. Install SDL_Image and define CPP_SDL2_USE_SDL_IMAGE to use image files" };
+		SDL_SetError( "tryed to call sdl::Surface ctor. This function should call IMG_Load() from SDL_Image.\n"
+			"This program was built without SDL_Image.\n"
+			"Please Install SDL_Image and #define CPP_SDL2_USE_SDL_IMAGE before including sdl.hpp to use this functionality" );
+		throw Exception("IMG_Load");
 	}
 
 #endif

--- a/sources/surface.hpp
+++ b/sources/surface.hpp
@@ -4,7 +4,11 @@
 #include <string>
 
 #include <SDL2/SDL_surface.h>
-#include <SDL2/SDL_image.h>
+
+#ifdef CPP_SDL2_USE_SDL_IMAGE
+#include <SDL_image.h>
+#endif
+
 #include "exception.hpp"
 #include "vec2.hpp"
 #include "rect.hpp"
@@ -72,11 +76,21 @@ public:
 		if (!surface_) throw Exception{ "SDL_CreateRGBSurfaceWithFormatFrom" };
 	}
 
+#ifdef CPP_SDL2_USE_SDL_IMAGE
 	Surface(std::string const& filename)
 		: surface_{ IMG_Load(filename.c_str()) }
 	{
 		if (!surface_) throw Exception{ "IMG_Load" };
 	}
+
+#else
+	Surface(std::string const& filename)
+		: surface_{nullptr}
+	{
+		if (!surface_) throw Exception{ "ctor using IMG_Load has been stubbed. Install SDL_Image and define CPP_SDL2_USE_SDL_IMAGE to use image files" };
+	}
+
+#endif
 
 	~Surface() { SDL_FreeSurface(surface_); }
 

--- a/sources/surface.hpp
+++ b/sources/surface.hpp
@@ -87,7 +87,7 @@ public:
 	Surface(std::string const& filename)
 		: surface_{nullptr}
 	{
-		SDL_SetError( "tryed to call sdl::Surface ctor. This function should call IMG_Load() from SDL_Image.\n"
+		SDL_SetError( "Tried to call sdl::Surface(std::string const& filename) ctor. This function should call IMG_Load() from SDL_Image.\n"
 			"This program was built without SDL_Image.\n"
 			"Please Install SDL_Image and #define CPP_SDL2_USE_SDL_IMAGE before including sdl.hpp to use this functionality" );
 		throw Exception("IMG_Load");


### PR DESCRIPTION
This PR introduce another configuration define that permit to specify that you want to use SDL image.

This could be done the other way around ( = having too #define something to **deactivate** the usage of SDL_Image).

Your call on that, but since it's only used in once constructor, and that there could be usages of the SDL that doesn't require creating surfaces in the SDL renderer form images, maybe keeping it optional is best.

I would argue for the same thing for other additional libraries  like SDL_mixer.