### PR TITLE
Add vulkan and GL windows to sdl::Window

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,12 @@ script:
   - export CXX=/usr/bin/g++-8
   - gcc -v && g++ -v && cmake --version
   - goback=$(pwd)
+  - mkdir vk
+  - cd vk
+  - travis_retry curl -L https://sdk.lunarg.com/sdk/download/1.1.82.1/linux/vulkansdk-linux-x86_64-1.1.82.1.tar.gz | tar xz
+  - cd 1.1.82.1
+  - source ./setup-env.sh
+  - cd $goback 
   - mkdir sdl
   - cd sdl
   - travis_retry curl -L https://www.libsdl.org/release/SDL2-2.0.8.tar.gz | tar xz

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Makes the content of the "sources" directory visible by your compiler. `#include
 
 By default, the code will throw exception in case of an SDL_Error. The Exception will contain the string returned by `SDL_GetError()`
 
+`cpp-sdl2` also conviniently wrap SDL's functionallities aimed at making cross-platform OpenGL/Vulkan developement easier. For instance, the window class can help you create an opengl context, or a vulkan instance/surface without having to worry if you are running on a Windows platform or something else. This functionality can be activated by defining `CPP_SDL2_GL_WINDOW`or `CPP_SDL2_VK_WINDOW` before including `sdl.hpp`
+
 Exception support can be disabled by defining `CPP_SDL2_NOEXCEPTIONS` in the preprocessor. 
 
 To be able to easilly load images into surfaces, you can install SDL_Image 2, and define `CPP_SDL2_USE_SDL_IMAGE`

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -5,10 +5,11 @@ set(CMAKE_CXX_STANDARD 17)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ./cmake-modules)
 find_package(SDL2 REQUIRED)
+find_package(Vulkan REQUIRED)
 
 include_directories(../sources/ ${SDL2_INCLUDE_DIRS})
 
 
 add_executable(example main.cpp)
-target_link_libraries(example ${SDL2_LIBRARIES})
+target_link_libraries(example ${SDL2_LIBRARIES} Vulkan::Vulkan)
 

--- a/example/main.cpp
+++ b/example/main.cpp
@@ -1,3 +1,6 @@
+#define CPP_SDL2_VK_WINDOW
+#define CPP_SDL2_GL_WINDOW
+
 #include "sdl.hpp"
 #include <cstdlib> // Using C-style rand
 #include <ctime>

--- a/sources/window.hpp
+++ b/sources/window.hpp
@@ -7,6 +7,11 @@
 #include "renderer.hpp"
 #include "vec2.hpp"
 
+#ifdef CPP_SDL2_VK_WINDOW
+#include <vulkan/vulkan.hpp>
+#include <SDL2/SDL_vulkan.h>
+#endif
+
 namespace sdl
 {
 
@@ -124,6 +129,106 @@ public:
 		}
 		return info;
 	}
+
+	#ifdef CPP_SDL2_VK_WINDOW
+	///Enumerate the requred extensions to create a VkSurfaceKHR on the current system
+	/// \return a vector of const char strings containing the extensions names
+	std::vector<const char*> vk_get_instance_extensions()
+	{
+		std::vector<const char*> extensions;
+		Uint32 count;
+
+		if(!SDL_Vulkan_GetInstanceExtensions(window_, &count, nullptr))
+			throw Exception("SDL_Vulkan_GetInstanceExtnesions");
+
+		extensions.resize(count);
+
+		if(!SDL_Vulkan_GetInstanceExtensions(window_, &count, extensions.data()))
+			throw Exception("SDL_Vulkan_GetInstaceExtensions");
+
+		return extensions; //Benefit from enforced RVO
+	}
+
+	///Cretate a vulkan surface for the current platform
+	/// \return your vulkan surface
+	VkSurfaceKHR vk_create_surface(VkInstance instance)
+	{
+		VkSurfaceKHR surface;
+		if(!SDL_Vulkan_CreateSurface(window_, instance, &surface)) throw Exception("SDL_Vulkan_CreateSurface");
+
+		return surface;
+	}
+
+	///Create a vulkan surface using the C++ wrapper around UniuqeHandle
+	vk::UniqueSurfaceKHR vk_create_unique_surface(vk::Instance instance)
+	{
+		auto nakedSurface = vk_create_surface(instance);
+		return vk::UniqueSurfaceKHR(nakedSurface, instance);
+	}
+#endif //vulkan methods
+
+#ifdef CPP_SDL2_GL_WINDOW
+
+	//This function is mostly used to set values regarding SDL GL context, and is intertwined with window createion.
+	//However, this can be called before createing the window. This wrapping is mostly for API consistency and for automatic error checking.
+	static void gl_set_attribute(SDL_GLattr attr, int val)
+	{
+		if(SDL_GL_SetAttribute(attr, val) < 0) throw Exception("SDL_GL_SetAttribute");
+	}
+
+	///Nested class that represent a managed OpenGL Context by the SDL
+	class GlContext
+	{
+	public:
+		///Create a GlContext for the given window. You should use sdl::Window::gl_create_context() insdtead of this
+		GlContext(SDL_Window* w) : context_{ SDL_GL_CreateContext(w) }, owner_{ w }
+		{
+			if(!context_) throw Exception("SDL_GL_CreateContext");
+		}
+
+		///Dtor will call SDL_GL_DeleteContext on the enclosed context
+		~GlContext()
+		{
+			SDL_GL_DeleteContext(context_);
+		}
+
+		//Only movable, not copyable
+		GlContext(GlContext& const) = delete;
+		GlContext& operator=(GlContext& const) = delete;
+
+		GlContext(GlContext&& other)
+		{
+			context_	   = other.context_;
+			owner_		   = other.owner_;
+			other.context_ = nullptr;
+		}
+
+		GlContext& operator=(GlContext&& other)
+		{
+			context_	   = other.context_;
+			owner_		   = other.owner_;
+			other.context_ = nullptr;
+
+			return *this;
+		}
+
+		void make_current()
+		{
+			if(SDL_GL_MakeCurrent(owner_, context_) < 0)
+				throw Exception("SDL_GL_MakeCurrent");
+		}
+
+	private:
+		SDL_GLContext context_ = nullptr;
+		SDL_Window* owner_	 = nullptr;
+	};
+
+	///Create an OpenGL context from the current window
+	GlContext create_context() { return GlContext{ window_ }; }
+
+	///Swap buffers for GL when using double buffering on the current window
+	void gl_swap() { SDL_GL_SwapWindow(window_); }
+#endif
 
 private:
 

--- a/sources/window.hpp
+++ b/sources/window.hpp
@@ -193,8 +193,8 @@ public:
 		}
 
 		//Only movable, not copyable
-		GlContext(GlContext& const) = delete;
-		GlContext& operator=(GlContext& const) = delete;
+		GlContext(GlContext const&) = delete;
+		GlContext& operator=(GlContext const&) = delete;
 
 		GlContext(GlContext&& other)
 		{


### PR DESCRIPTION
Here's the few gl/vk functions implemented in window.hpp. PR is mostly to get inputs on the solution than to be merged right away (but it's mostly done)

Vulkan functions are basically fine, but here's some things about the implementation of OpenGL here.

Since the created context is an object that need cleanup, the window now has a nested "GlContext" public class. I would lke to know if it's a good solution or not. The pointer-taking ctor should only be called from within the window class. 

Do we need to actively hide the GlContext(SDL_Window* w)  ctor from the user, or do we just not care?

Thoughts?

fix #12 