### PR TITLE
[WIP] fix SDL include path

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -7,9 +7,9 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ./cmake-modules)
 find_package(SDL2 REQUIRED)
 find_package(Vulkan REQUIRED)
 
-include_directories(../sources/ ${SDL2_INCLUDE_DIRS})
+include_directories(../sources/ )
 
 
 add_executable(example main.cpp)
-target_link_libraries(example ${SDL2_LIBRARIES} Vulkan::Vulkan)
+target_link_libraries(example SDL2::SDL2 Vulkan::Vulkan)
 

--- a/sources/color.hpp
+++ b/sources/color.hpp
@@ -3,7 +3,7 @@
 #include <ostream>
 
 #include "exception.hpp"
-#include <SDL2/SDL_pixels.h>
+#include <SDL_pixels.h>
 
 namespace sdl
 {

--- a/sources/event.hpp
+++ b/sources/event.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL_events.h>
+#include <SDL_events.h>
 
 #include <functional>
 #include <map>
@@ -8,7 +8,7 @@
 
 #include "exception.hpp"
 
-#include <SDL2/begin_code.h> // use SDL2 packing
+#include <begin_code.h> // use SDL2 packing
 
 namespace sdl
 {
@@ -370,4 +370,4 @@ inline void set_event_state(Uint32 type, Event::State state)
 
 } // namespace sdl
 
-#include <SDL2/close_code.h>
+#include <close_code.h>

--- a/sources/exception.hpp
+++ b/sources/exception.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <string_view>
 
-#include <SDL2/SDL_error.h>
+#include <SDL_error.h>
 
 ///Define to deactivate exception support
 #ifdef CPP_SDL2_NOEXCEPTIONS

--- a/sources/pixel.hpp
+++ b/sources/pixel.hpp
@@ -2,7 +2,7 @@
 
 #include "color.hpp"
 #include "exception.hpp"
-#include <SDL2/SDL_pixels.h>
+#include <SDL_pixels.h>
 
 namespace sdl
 {

--- a/sources/rect.hpp
+++ b/sources/rect.hpp
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-#include <SDL2/SDL_rect.h>
+#include <SDL_rect.h>
 #include <algorithm>
 
 #include "vec2.hpp"

--- a/sources/renderer.hpp
+++ b/sources/renderer.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_render.h>
+#include <SDL.h>
+#include <SDL_render.h>
 #include <utility>
 #include <vector>
 

--- a/sources/sdl.hpp
+++ b/sources/sdl.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include "color.hpp"
 #include "event.hpp"

--- a/sources/shared_object.hpp
+++ b/sources/shared_object.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL.h>
+#include <SDL.h>
 
 #include <string>
 

--- a/sources/surface.hpp
+++ b/sources/surface.hpp
@@ -3,7 +3,7 @@
 #include <string>
 #include <utility>
 
-#include <SDL2/SDL_surface.h>
+#include <SDL_surface.h>
 
 #ifdef CPP_SDL2_USE_SDL_IMAGE
 #include <SDL_image.h>

--- a/sources/texture.hpp
+++ b/sources/texture.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <SDL2/SDL_render.h>
+#include <SDL_render.h>
 #include <string>
 
 #include "color.hpp"

--- a/sources/vec2.hpp
+++ b/sources/vec2.hpp
@@ -1,6 +1,6 @@
 ﻿#pragma once
 
-#include <SDL2/SDL_rect.h>
+#include <SDL_rect.h>
 #include <algorithm>
 #include <cmath>
 #include <ostream>

--- a/sources/window.hpp
+++ b/sources/window.hpp
@@ -1,14 +1,14 @@
 #pragma once
 
-#include <SDL2/SDL.h>
-#include <SDL2/SDL_syswm.h>
+#include <SDL.h>
+#include <SDL_syswm.h>
 #include <string>
 
 #include "renderer.hpp"
 #include "vec2.hpp"
 
 #ifdef CPP_SDL2_VK_WINDOW
-#include <SDL2/SDL_vulkan.h>
+#include <SDL_vulkan.h>
 #include <vulkan/vulkan.hpp>
 #endif
 


### PR DESCRIPTION
This PR remove the SDL2/ prefix on all the includes.
CMake module was updated to use more mordern CMake features in the CI/example directory.

We need to decide if cpp-sdl2 headers needs to be included in a subdirectory (they probably should).