### PR TITLE
use CMAKE_DL_LIBS

### DIFF
--- a/examples/gl/CMakeLists.txt
+++ b/examples/gl/CMakeLists.txt
@@ -17,7 +17,7 @@ file(GLOB cppsdl2headers ../sources/cpp-sdl2/*.hpp)
 add_executable(gl-example main.cpp glad/src/glad.c ${cppsdl2headers})
 
 target_link_libraries(gl-example SDL2::SDL2 SDL2::SDL2main)
-target_link_libraries(gl-example OpenGL::GL)
+target_link_libraries(gl-example OpenGL::GL ${CMAKE_DL_LIBS})
 
  if (CMAKE_VERSION VERSION_GREATER 3.8.0 AND MSVC)
 	set_target_properties(gl-example PROPERTIES VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")


### PR DESCRIPTION
thanks for provide us this great wrapper.
can't get the libdl for ubuntu1904, need to use the CMAKE_DL_LIBS.

```shell
anhong@ubuntu1904:~/sdl2_cpp_b$ make
Scanning dependencies of target gl-example
[ 10%] Building CXX object gl/CMakeFiles/gl-example.dir/main.cpp.o
[ 20%] Building C object gl/CMakeFiles/gl-example.dir/glad/src/glad.c.o
[ 30%] Linking CXX executable gl-example
/usr/bin/ld: CMakeFiles/gl-example.dir/glad/src/glad.c.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [gl/CMakeFiles/gl-example.dir/build.make:102: gl/gl-example] Error 1
make[1]: *** [CMakeFiles/Makefile2:91: gl/CMakeFiles/gl-example.dir/all] Error 2
make: *** [Makefile:84: all] Error 2
```